### PR TITLE
[PHP 7.4 - Windows] Support libzip_a.lib for VS16

### DIFF
--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -7,6 +7,10 @@ if (PHP_ZIP != "no") {
 		CHECK_HEADER_ADD_INCLUDE("zipconf.h", "CFLAGS_ZIP", PHP_PHP_BUILD + "\\lib\\libzip\\include;" + PHP_EXTRA_LIBS + "\\libzip\\include;" + PHP_ZIP) &&
 		(PHP_ZIP_SHARED && CHECK_LIB("libzip.lib", "zip", PHP_ZIP) || CHECK_LIB("libzip_a.lib", "zip", PHP_ZIP) && CHECK_LIB("libbz2_a.lib", "zip", PHP_ZIP) && CHECK_LIB("zlib_a.lib", "zip", PHP_ZIP))
 	) {
+		if (VS_TOOLSET && VCVERS >= 1920) {
+			// lipzip_a.lib for VS16 ships with zip_algorithm_xz and needs symbols for lzma_*
+			CHECK_LIB("liblzma_a.lib", "zip", PHP_ZIP);
+		}
 		EXTENSION('zip', 'php_zip.c zip_stream.c');
 
 		if (get_define("LIBS_ZIP").match("libzip_a(?:_debug)?\.lib")) {


### PR DESCRIPTION
libzip_a.lib for VS16 has zip_algorithm_xz enabled and needs lzma symbols
See downloads at https://windows.php.net/downloads/php-sdk/deps/vs16/x64/ or at
https://downloads.php.net/~windows/php-sdk/deps/vs16/x64/

I updated all of my VS16 dependencies for OpenSSL 3.0.12 and applied
https://git.remirepo.net/cgit/rpms/scl-php74/php.git/plain/php-7.4.26-openssl3.patch
Thanks for providing that patch!

Almost worked when I compiled PHP 7.4 with the security backports in my VS16 environment, except for
```
        rc /nologo /fo N:\php-sdk\php74dev\x64\Release\php7.dll.res /d FILE_DESCRIPTION="\"PHP Script Interpreter\""  /d FILE_NAME="\"php7.dll\"" /d PRODUCT_NAME="\"PHP Script Interpreter\""  /IN:\php-sdk\php74dev\x64\Release /d MC_INCLUDE="\"N:\php-sdk\php74dev\x64\Release\wsyslog.rc\""  win32\build\template.rc
libiconv_a.lib(iconv1.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
   Creating library N:\php-sdk\php74dev\x64\Release\php7.lib and object N:\php-sdk\php74dev\x64\Release\php7.exp
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_code
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_end
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_lzma_preset
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_stream_encoder
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_alone_encoder
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_stream_decoder
libzip_a.lib(zip_algorithm_xz.obj) : error LNK2001: unresolved external symbol lzma_alone_decoder
N:\php-sdk\php74dev\x64\Release\php7.dll : fatal error LNK1120: 7 unresolved externals
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\link.exe"' : return code '0x460'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
```
This PR fixes that and makes it possible to compile PHP 7.4 including OpenSSL 3.0.12 with the VS16 compiler.
Proof in the pudding:
https://phpdev.toolsforresearch.com/php-7.4.33-nts-Win32-vs16-x64.htm
https://phpdev.toolsforresearch.com/php-7.4.33-nts-Win32-vs16-x64.zip

@remicollet Please take a quick look and merge. It only changes config.w32, so has no impact on other platforms.